### PR TITLE
Added missing / in closing tags in examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,10 +284,10 @@
           <h3>Create a basic page layout.</h3>
 
           <h4 class='no-js'>Linux and macOS</h4>
-          <pre class='linux macos'><code class='language-mixed'><span class='language-bash'>echo '</span><span class='language-html'>&lt;body&gt;&lt;h1&gt;Hello, world!&lt;h1&gt;&lt;body&gt;</span><span class='hljs-string'>'</span><span class='language-bash'> &gt; .hugo/layouts/index.html</span></code></pre>
+          <pre class='linux macos'><code class='language-mixed'><span class='language-bash'>echo '</span><span class='language-html'>&lt;body&gt;&lt;h1&gt;Hello, world!&lt;/h1&gt;&lt;/body&gt;</span><span class='hljs-string'>'</span><span class='language-bash'> &gt; .hugo/layouts/index.html</span></code></pre>
 
           <h4 class='no-js'>Windows</h4>
-          <pre class='windows'><code class='language-mixed'><span class='language-powershell'>echo '</span><span class='language-html'>&lt;body&gt;&lt;h1&gt;Hello, world!&lt;h1&gt;&lt;body&gt;</span><span class='hljs-string'>'</span><span class='language-powershell'> | Out-File -Encoding UTF8 .hugo/layouts/index.html</span></code></pre>
+          <pre class='windows'><code class='language-mixed'><span class='language-powershell'>echo '</span><span class='language-html'>&lt;body&gt;&lt;h1&gt;Hello, world!&lt;/h1&gt;&lt;/body&gt;</span><span class='hljs-string'>'</span><span class='language-powershell'> | Out-File -Encoding UTF8 .hugo/layouts/index.html</span></code></pre>
 
           <aside>
             <h3>Tip</h3>


### PR DESCRIPTION
Both the `<h1>` and the `<body>` tags in the examples were lacking a / in their closing tags. :)